### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/security/lambda/sendSecurityAlert/inspector.py
+++ b/security/lambda/sendSecurityAlert/inspector.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import json
 import os
-
+from urllib.parse import urlparse
 import boto3
 
 ses_client = boto3.client("ses")
@@ -36,7 +36,7 @@ def send_inspector_alert(event):
     vuln_details = detail.get("packageVulnerabilityDetails", {})
     cve_id = vuln_details.get("vulnerabilityId", "Unknown CVE")
     reference_urls = vuln_details.get("referenceUrls", [])
-    nvd_url = next((url for url in reference_urls if "nvd.nist.gov" in url), "No NVD link available")
+    nvd_url = next((url for url in reference_urls if urlparse(url).hostname == "nvd.nist.gov"), "No NVD link available")
     
     vulnerable_packages = vuln_details.get("vulnerablePackages", [])
     package_info = []


### PR DESCRIPTION
Potential fix for [https://github.com/GSI-Xapiens-CSIRO/BGSI-GeneticAnalysisSupportPlatformIndonesia-GASPI/security/code-scanning/1](https://github.com/GSI-Xapiens-CSIRO/BGSI-GeneticAnalysisSupportPlatformIndonesia-GASPI/security/code-scanning/1)

To fix the issue, the code should parse the URL using Python's `urllib.parse` module and validate the hostname explicitly. Instead of checking if `"nvd.nist.gov"` is a substring of the URL, the code should extract the hostname and ensure it matches `nvd.nist.gov`. This approach is robust against malicious URLs that embed the target string in unexpected locations.

The fix involves:
1. Importing `urlparse` from `urllib.parse`.
2. Replacing the substring check with a parsed hostname check.
3. Ensuring that the hostname matches `nvd.nist.gov` exactly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
